### PR TITLE
Fixes on Lab 01 - Reverse Shells

### DIFF
--- a/01-Reverse Shells/README.md
+++ b/01-Reverse Shells/README.md
@@ -99,7 +99,7 @@ cd n2h-red/01-Reverse\ Shells
 
 # pull and run the docker image
 # LEAVE THIS WINDOW OPEN
-docker compose up
+docker-compose up
 ```
 
 

--- a/01-Reverse Shells/README.md
+++ b/01-Reverse Shells/README.md
@@ -230,9 +230,9 @@ Connection received from [some IP] <some port number>
 # invoke python TTY module
 python -c 'import pty;pty.spawn("/bin/bash")'
 
-# press \<ctrl-z\> to background the session
+# press <ctrl-z> to background the session
 # you'll be back in the 'kali' shell for these steps
-stty raw -echo; fg # push \<enter\> twice
+stty raw -echo; fg # push <enter> twice
 
 # now you're back in the reverse shell
 export TERM=xterm


### PR DESCRIPTION
There are three errors in the `01-Reverse Shells` guide. One of them is an incorrect command for Docker Compose. The command in the guide is `docker-compose`. The correct command is `docker-compose`. The other two errors are visual; they do not prevent others from following the guide. Backslashes are unnecessary before angled brackets (<>) when the angled brackets are in code blocks. For example: `\<ctrl-z\>` -> `<ctrl-z>`